### PR TITLE
Support reading and saving meta information in dataloader and utils

### DIFF
--- a/dataset/dataloader.py
+++ b/dataset/dataloader.py
@@ -18,6 +18,7 @@ from monai.transforms import (
     apply_transform,
     RandZoomd,
     RandCropByLabelClassesd,
+    CopyItemsd,
 )
 
 import collections.abc
@@ -394,6 +395,7 @@ def get_loader_without_gt(args):
     val_transforms = Compose(
         [
             LoadImaged(keys=["image"]),
+            CopyItemsd(keys=["image_meta_dict"], names=["original_meta_dict"]), # copy the meta data of original CT before cropping and resampling
             AddChanneld(keys=["image"]),
             Orientationd(keys=["image"], axcodes="RAS"),
             # ToTemplatelabeld(keys=['label']),

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -671,7 +671,7 @@ def save_results(batch, save_dir, input_transform, organ_list):
                 to_tensor=True,
             ),
             SaveImaged(keys=ORGAN_NAME[organ-1], 
-                    meta_keys="image_meta_dict" , 
+                    meta_keys="original_meta_dict" , # Restore to original meta information
                     output_dir=save_dir, 
                     output_postfix=ORGAN_NAME[organ-1], 
                     resample=False


### PR DESCRIPTION
Hi, thanks for your excellent work.

I encountered an issue while running inference on my CT images. The predicted mask's meta information (such as spacing, origin, etc.) does not match the original CT image's meta information. This discrepancy prevents me from visualizing the predicted results properly in 3D Slicer.

To address this, I modified the ```get_loader_without_gt()``` and ```save_results()``` functions to ensure that the prediction masks preserve the original meta information when saved.

However, due to the lack of GPU hardware, I am unable to verify whether this modification affects any other functionalities beyond inference.

This is my first time submitting a pull request, and I hope this change can be useful. Thank you!